### PR TITLE
Features/duration

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,3 +1,4 @@
+// Package cache provides implementations for the ratelimiter.
 package cache
 
 import (
@@ -9,7 +10,7 @@ import (
 // Limiter defines an interface for ratelimiter implementations
 type Limiter interface {
 	Limit(identity string, limit int, window time.Duration) (isLimitExceeded bool, remaining int, reset time.Duration, err error)
-	QueryLimit(identity string) (remaining int, err error) // QueryLimit allows querying of the current remaining limit for an identity
+	QueryLimit(identity string) (remaining int, err error)
 }
 
 var logger log.Glogger // Replace with generic via interface

--- a/cache/inmemory.go
+++ b/cache/inmemory.go
@@ -2,11 +2,15 @@ package cache
 
 import "time"
 
-// InMemoryLimiter defines a redis backed rate limiter implementation
-type InMemoryLimiter struct {
-}
+// InMemoryLimiter defines a stubbed in-memory rate limiter implementation.
+//
+// This implementation does not provide real rate limiting. Instead it is intended
+// as a stubbed interface for mocking/testing when you don't have (or want to use)
+// a real redis instance.
+type InMemoryLimiter struct{}
 
-// Limit provides rate limiting functionality
+// Limit provides stubbed rate limiting functionality. For the in-memory implementation
+// this will always return rateLimitExceeded=false
 func (rl *InMemoryLimiter) Limit(identity string, limit int, window time.Duration) (rateLimitExceeded bool, remaining int, reset time.Duration, lastError error) {
 
 	logger.Debug("Rate limiting (in memory) for identity: [%s] Limit: [%d] Window: [%d]", identity, limit, window)

--- a/cache/redis.go
+++ b/cache/redis.go
@@ -34,6 +34,18 @@ return current`)
 }()
 
 // Limit provides rate limiting functionality
+//
+//   Input
+//
+//   * identity - (string) a unique string to identify the user for which you're ratelimiting
+//   * limit    - (int) number of requests allowable within window
+//   * window   - (time.Duration) length of the window
+//
+//   Output
+//
+//   * exceeded  - (boolean) true if rate limit has been exceeded
+//   * remaining - (int) number of requests still allowable in current window
+//   * reset     - (time.Duration) length of time until window resets
 func (rl *RedisLimiter) Limit(identity string, limit int, window time.Duration) (rateLimitExceeded bool, remaining int, reset time.Duration, lastError error) {
 
 	logger.Debug("Rate limiting for identity: [%s] Limit: [%d] Window: [%d]", identity, limit, window)


### PR DESCRIPTION
Using a `time.Duration` to specify the time window for limiting instead of a plain number.
